### PR TITLE
Removed comments, compressed condition clause to single check

### DIFF
--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -419,22 +419,14 @@ def _convert_node_attr_types(G, dtypes=None):
     Returns
     -------
     G : networkx.MultiDiGraph
-    
-    Modified to include detection of list, dict, and set type
-    node attribute strings and handle their translation into
-    python objects of the correct type.
     """
     for _, data in G.nodes(data=True):
         # first, eval stringified lists, dicts or sets to convert them to objects
         # edge attributes might have a single value, or a list if simplified
         for attr, value in data.items():
             # check for stringified lists
-            if value.startswith("[") and value.endswith("]"):
-                with contextlib.suppress(SyntaxError, ValueError):
-                    data[attr] = ast.literal_eval(value)
-            # check for stringified dicts or sets: both can be converted
-            # to python objects using ast.literal_eval()
-            if value.startswith("{") and value.endswith("}"):
+            if ((value.startswith("[") and value.endswith("]")) 
+                or (value.startswith("{") and value.endswith("}"))):
                 with contextlib.suppress(SyntaxError, ValueError):
                     data[attr] = ast.literal_eval(value)
     
@@ -457,10 +449,6 @@ def _convert_edge_attr_types(G, dtypes=None):
     Returns
     -------
     G : networkx.MultiDiGraph
-    
-    Modified to include detection of list, dict, and set type
-    node attribute strings and handle their translation into
-    python objects of the correct type.
     """
     # for each edge in the graph, eval attribute value lists and convert types
     for _, _, data in G.edges(data=True, keys=False):
@@ -470,13 +458,8 @@ def _convert_edge_attr_types(G, dtypes=None):
         # first, eval stringified lists, dicts or sets to convert them to objects
         # edge attributes might have a single value, or a list if simplified
         for attr, value in data.items():
-            # check for stringified lists
-            if value.startswith("[") and value.endswith("]"):
-                with contextlib.suppress(SyntaxError, ValueError):
-                    data[attr] = ast.literal_eval(value)
-            # check for stringified dicts or sets: both can be converted
-            # to python objects using ast.literal_eval()
-            if value.startswith("{") and value.endswith("}"):
+            if ((value.startswith("[") and value.endswith("]")) 
+                or (value.startswith("{") and value.endswith("}"))):
                 with contextlib.suppress(SyntaxError, ValueError):
                     data[attr] = ast.literal_eval(value)
 


### PR DESCRIPTION
Removing docstring additions from first PR.
Compressing condition clause for checking if string is stringified list, set or dict to only have a single if clause.
Checked for trailing white spaces.