### PR TITLE
After lint testing with automatic change

### DIFF
--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -425,11 +425,12 @@ def _convert_node_attr_types(G, dtypes=None):
         # edge attributes might have a single value, or a list if simplified
         for attr, value in data.items():
             # check for stringified lists
-            if ((value.startswith("[") and value.endswith("]"))
-                or (value.startswith("{") and value.endswith("}"))):
+            if (value.startswith("[") and value.endswith("]")) or (
+                value.startswith("{") and value.endswith("}")
+            ):
                 with contextlib.suppress(SyntaxError, ValueError):
                     data[attr] = ast.literal_eval(value)
-    
+
         for attr in data.keys() & dtypes.keys():
             data[attr] = dtypes[attr](data[attr])
     return G
@@ -458,8 +459,9 @@ def _convert_edge_attr_types(G, dtypes=None):
         # first, eval stringified lists, dicts or sets to convert them to objects
         # edge attributes might have a single value, or a list if simplified
         for attr, value in data.items():
-            if ((value.startswith("[") and value.endswith("]"))
-                or (value.startswith("{") and value.endswith("}"))):
+            if (value.startswith("[") and value.endswith("]")) or (
+                value.startswith("{") and value.endswith("}")
+            ):
                 with contextlib.suppress(SyntaxError, ValueError):
                     data[attr] = ast.literal_eval(value)
 


### PR DESCRIPTION
Local env created from env-ci.yml, tried to see how to run the tests, ended up calling format.sh and lint_test.sh, which did an automatic change to the condition clause formatting, which I happened to see because I had the file open in Notepad++ and it asked to reload it from being changed on disk.  However, I cannot find how to see test results locally, for example any logfile from the testing, as I get no results in the shell windows at all. 
It's unclear to me what more I can do, so will merge this last automatic edit...
